### PR TITLE
Add discrete mi score

### DIFF
--- a/src/drvi/utils/metrics/__init__.py
+++ b/src/drvi/utils/metrics/__init__.py
@@ -5,11 +5,13 @@ from ._pairwise import (
     local_mutual_info_score,
     nn_alignment_score,
     spearman_correlataion_score,
+    discrete_mutual_info_score,
 )
 
 __all__ = [
     "nn_alignment_score",
     "local_mutual_info_score",
+    "discrete_mutual_info_score",
     "global_dim_mutual_info_score",
     "spearman_correlataion_score",
     "most_similar_averaging_score",

--- a/tests/utils/metrics/test_disentanglement_discrete_benchmark.py
+++ b/tests/utils/metrics/test_disentanglement_discrete_benchmark.py
@@ -14,8 +14,10 @@ class TestDiscreteDisentanglementBenchmark:
 
         return categorical_features, categorical_features_01, fit_continuous_latent, random_continuous_latent
 
-    def _general_test_pipeline(self, continuous_latent, categorical_features=None, categorical_features_01=None):
-        METRICS = ["ASC", "SPN", "SMI"]
+    def _general_test_pipeline(
+        self, continuous_latent, categorical_features=None, categorical_features_01=None, **kwargs
+    ):
+        METRICS = ["ASC", "SPN", "SMI-cont", "SMI-disc"]
         AGGREGATION_METHODS = ["LMS", "MSAS", "MSGS"]
 
         benchmark = DiscreteDisentanglementBenchmark(
@@ -24,6 +26,7 @@ class TestDiscreteDisentanglementBenchmark:
             one_hot_target=categorical_features_01,
             metrics=METRICS,
             aggregation_methods=AGGREGATION_METHODS,
+            **kwargs,
         )
         benchmark.evaluate()
         return benchmark
@@ -86,3 +89,14 @@ class TestDiscreteDisentanglementBenchmark:
 
         for metric in results_gt:
             assert np.all(results_random[metric] < results_gt[metric]), f"Results for {metric} do not match"
+
+    def test_benchmarker_with_additional_metric_params(self):
+        categorical_features, categorical_features_01, fit_continuous_latent, random_continuous_latent = (
+            self.make_test_data()
+        )
+
+        self._general_test_pipeline(
+            continuous_latent=fit_continuous_latent,
+            categorical_features=categorical_features,
+            additional_metric_params={"SMI-disc": {"n_bins": 3}},
+        )


### PR DESCRIPTION
The scikit-learn implementation of MI does not work for needle-in-the-haystack scenarios (happening in our rare cell types).
More details: [https://github.com/scikit-learn/scikit-learn/issues/30772](https://github.com/scikit-learn/scikit-learn/issues/30772)

Accordingly, we discretize the embeddings ourselves and calculate the MI score using the information theory definition.