### PR TITLE
Release 0.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.11.13
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,34 +8,34 @@
 
 ## [0.1.7] - 2025-05-30
 
--   Fix categorical lookup for reconstruction
+- Fix categorical lookup for reconstruction
 
 ## [0.1.6] - 2025-05-22
 
--   Allow kwargs to pass through in plot_relevant_genes_on_umap
--   Update project CI structure
--   Extract tutorial notebooks to another repo to keep this repo clean
+- Allow kwargs to pass through in plot_relevant_genes_on_umap
+- Update project CI structure
+- Extract tutorial notebooks to another repo to keep this repo clean
 
 ## [0.1.5] - 2025-05-09
 
--   Refactor benchmarking code for better reusability
--   Revert callable for mean and var activation
+- Refactor benchmarking code for better reusability
+- Revert callable for mean and var activation
 
 ## [0.1.4] - 2025-04-17
 
--   Limit anndata version for compatibility with old scvi-tools
+- Limit anndata version for compatibility with old scvi-tools
 
 ## [0.1.3] - 2025-02-12
 
--   Introduce mean activation to make non-negative latents possible (docs will come later)
--   Better communication when Merlin is not installed
--   Raise error when interpretability is called on model with continues covariates
+- Introduce mean activation to make non-negative latents possible (docs will come later)
+- Better communication when Merlin is not installed
+- Raise error when interpretability is called on model with continues covariates
 
 ## [0.1.2] - 2024-11-11
 
--   No change in DRVI code
--   Fix github workflow, tests, docs, and pypi publishing pipelines
+- No change in DRVI code
+- Fix github workflow, tests, docs, and pypi publishing pipelines
 
 ## [0.1.0] - 2024-08-21
 
--   Moved all files from repo to scverse cookiecutter project template
+- Moved all files from repo to scverse cookiecutter project template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,40 @@
 
 ## [Unreleased]
 
+## [0.1.8] -
+
+-
+
 ## [0.1.7] - 2025-05-30
 
-- Fix categorical lookup for reconstruction
+-   Fix categorical lookup for reconstruction
 
 ## [0.1.6] - 2025-05-22
 
-- Allow kwargs to pass through in plot_relevant_genes_on_umap
-- Update project CI structure
-- Extract tutorial notebooks to another repo to keep this repo clean
+-   Allow kwargs to pass through in plot_relevant_genes_on_umap
+-   Update project CI structure
+-   Extract tutorial notebooks to another repo to keep this repo clean
 
 ## [0.1.5] - 2025-05-09
 
-- Refactor benchmarking code for better reusability
-- Revert callable for mean and var activation
+-   Refactor benchmarking code for better reusability
+-   Revert callable for mean and var activation
 
 ## [0.1.4] - 2025-04-17
 
-- Limit anndata version for compatibility with old scvi-tools
+-   Limit anndata version for compatibility with old scvi-tools
 
 ## [0.1.3] - 2025-02-12
 
-- Introduce mean activation to make non-negative latents possible (docs will come later)
-- Better communication when Merlin is not installed
-- Raise error when interpretability is called on model with continues covariates
+-   Introduce mean activation to make non-negative latents possible (docs will come later)
+-   Better communication when Merlin is not installed
+-   Raise error when interpretability is called on model with continues covariates
 
 ## [0.1.2] - 2024-11-11
 
-- No change in DRVI code
-- Fix github workflow, tests, docs, and pypi publishing pipelines
+-   No change in DRVI code
+-   Fix github workflow, tests, docs, and pypi publishing pipelines
 
 ## [0.1.0] - 2024-08-21
 
-- Moved all files from repo to scverse cookiecutter project template
+-   Moved all files from repo to scverse cookiecutter project template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
-## [0.1.8] -
+## [0.1.8] - 2025-06-22
 
--
+- Discretize latent dimension values in MI for benchmarking due to [this bug](https://github.com/scikit-learn/scikit-learn/issues/30772).
+- Fix a minor issue with `drvi.utils.tl.traverse_latent`
 
 ## [0.1.7] - 2025-05-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["hatchling"]
 
 [project]
 name = "drvi-py"
-version = "0.1.7"
+version = "0.1.8"
 description = "Unsupervised Deep Disentangled Representation of Single-Cell Omics"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/drvi/utils/metrics/__init__.py
+++ b/src/drvi/utils/metrics/__init__.py
@@ -1,6 +1,7 @@
 from ._aggregation import latent_matching_score, most_similar_averaging_score, most_similar_gap_score
 from ._benchmark import DiscreteDisentanglementBenchmark
 from ._pairwise import (
+    discrete_mutual_info_score,
     global_dim_mutual_info_score,
     local_mutual_info_score,
     nn_alignment_score,
@@ -10,6 +11,7 @@ from ._pairwise import (
 __all__ = [
     "nn_alignment_score",
     "local_mutual_info_score",
+    "discrete_mutual_info_score",
     "global_dim_mutual_info_score",
     "spearman_correlataion_score",
     "most_similar_averaging_score",

--- a/src/drvi/utils/metrics/_benchmark.py
+++ b/src/drvi/utils/metrics/_benchmark.py
@@ -12,7 +12,7 @@ from drvi.utils.metrics._pairwise import (
 )
 
 AVAILABLE_METRICS = {
-    # ASC is generally unsuitable for discrete targets. We suggest Kendall's tau instead.
+    # ASC is generally unsuitable for discrete targets.
     # More info: https://www.biorxiv.org/content/10.1101/2024.11.06.622266v1.full.pdf lines 985 to 989
     "ASC": spearman_correlataion_score,
     "SPN": nn_alignment_score,

--- a/src/drvi/utils/metrics/_benchmark.py
+++ b/src/drvi/utils/metrics/_benchmark.py
@@ -12,6 +12,8 @@ from drvi.utils.metrics._pairwise import (
 )
 
 AVAILABLE_METRICS = {
+    # ASC is generally unsuitable for discrete targets. We suggest Kendall's tau instead.
+    # More info: https://www.biorxiv.org/content/10.1101/2024.11.06.622266v1.full.pdf lines 985 to 989
     "ASC": spearman_correlataion_score,
     "SPN": nn_alignment_score,
     # SMI-cont is not working as expected. More info: https://github.com/scikit-learn/scikit-learn/issues/30772

--- a/src/drvi/utils/tools/interpretability/_latent_traverse.py
+++ b/src/drvi/utils/tools/interpretability/_latent_traverse.py
@@ -16,7 +16,8 @@ def iterate_dimensions(
     n_samples: int = 100,
 ):
     assert n_steps % 2 == 0
-    assert np.all(latent_min <= 0) & np.all(latent_max >= 0)
+    # Sometimes it is negligibly not like below
+    # assert np.all(latent_min <= 0) & np.all(latent_max >= 0)
 
     dim_ids = (
         latent_dims.reshape(-1, 1, 1)
@@ -111,10 +112,10 @@ def make_traverse_adata(
     print(f"Input latent shape: control: {control_data.shape}, effect: {effect_data.shape}")
     # control and effect in mean parameter space
     control_mean_param = model.decode_latent_samples(
-        control_data, lib=lib_vector, cat_key=cat_vector, cont_key=None, **kwargs
+        control_data, lib=lib_vector, cat_values=cat_vector, cont_values=None, **kwargs
     )
     effect_mean_param = model.decode_latent_samples(
-        effect_data, lib=lib_vector, cat_key=cat_vector, cont_key=None, **kwargs
+        effect_data, lib=lib_vector, cat_values=cat_vector, cont_values=None, **kwargs
     )
     print(f"Output mean param shape: control: {control_mean_param.shape}, effect: {effect_mean_param.shape}")
 

--- a/tests/integration_tests/test_simple_pipeline.py
+++ b/tests/integration_tests/test_simple_pipeline.py
@@ -1,0 +1,136 @@
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scanpy as sc
+from scipy import sparse
+
+import drvi
+
+
+class TestSimplePipelineOfTrainingAndInterpretability:
+    n = 50
+    g = 20
+    c = 2
+    b = 5
+
+    def make_test_adata(self, is_sparse=True):
+        N, G, C, B = self.n, self.g, self.c, self.b
+
+        ct_list = np.sort(np.random.choice(range(C), N))[:, np.newaxis]
+        g_exp_list = np.sort(np.random.choice(range(C), G))[:, np.newaxis]
+        ct_array = (np.indices((N, C))[1] == ct_list) + 0.0
+        g_exp_array = (np.indices((G, C))[1] == g_exp_list) + 0.0
+
+        batch_list = np.random.choice(range(B), N)[:, np.newaxis]
+        batch_list_2 = np.random.choice(range(B), N)[:, np.newaxis]
+        exp_indicator = ct_array @ g_exp_array.T
+        g_mean_list = np.exp((np.random.random(G) + 0.5) * 2)[:, np.newaxis]
+
+        exp_matrix = np.random.poisson(exp_indicator * g_mean_list.T).astype(np.float32)
+
+        adata = ad.AnnData(
+            X=sparse.csr_matrix(exp_matrix),
+            obs=pd.DataFrame(
+                {
+                    "cell_type": [f"ct_{ct}" for ct in ct_list[:, 0]],
+                    "batch": [f"batch_{bid}" for bid in batch_list[:, 0]],
+                    "batch_2": [f"batch_{bid}" for bid in batch_list_2[:, 0]],
+                },
+                index=[f"cell_{i}" for i in range(N)],
+            ),
+            var=pd.DataFrame(
+                {
+                    "gene_mean": g_mean_list[:, 0],
+                    "gene_active_signature": np.apply_along_axis(
+                        lambda x: "".join(x), axis=1, arr=g_exp_array.astype(str)
+                    ),
+                },
+                index=[f"gene_{i}" for i in range(G)],
+            ),
+        )
+
+        adata.obs["total_counts"] = adata.X.sum(axis=1)
+        adata.layers["counts"] = adata.X.copy()
+        adata.layers["lognorm"] = np.log1p(adata.X)
+
+        if not is_sparse:
+            adata.X = adata.X.A
+            for l in ["counts", "lognorm"]:
+                adata.layers[l] = adata.layers[l].A
+
+        return adata
+
+    def test_whole_integration_and_interpretability(self):
+        adata = self.make_test_adata()
+
+        drvi.model.DRVI.setup_anndata(
+            adata,
+            categorical_covariate_keys=["batch"],
+            layer="counts",
+            is_count_data=True,
+        )
+        model = drvi.model.DRVI(
+            adata,
+            n_latent=8,
+            encoder_dims=[128],
+            decoder_dims=[128],
+            gene_likelihood="pnb_softmax",
+            categorical_covariates=["batch"],
+            decoder_reuse_weights="everywhere",
+        )
+        print(model.module)
+        model.train(accelerator="cpu", max_epochs=100)
+        embed = ad.AnnData(model.get_latent_representation(), obs=adata.obs)
+
+        drvi.utils.tl.set_latent_dimension_stats(model, embed)
+
+        traverse_adata = drvi.utils.tl.traverse_latent(model, embed, n_samples=2, max_noise_std=0.0)
+        drvi.utils.tl.calculate_differential_vars(traverse_adata)
+
+        return {
+            "adata": adata,
+            "model": model,
+            "embed": embed,
+            "traverse_adata": traverse_adata,
+        }
+
+    def test_plotting_functions(self):
+        train_results = self.test_whole_integration_and_interpretability()
+        adata = train_results["adata"]
+        embed = train_results["embed"]
+        traverse_adata = train_results["traverse_adata"]
+
+        # pre-processing
+        sc.pp.neighbors(embed, use_rep="X", n_pcs=embed.X.shape[1])
+        sc.tl.umap(embed)
+        sc.pp.pca(embed)
+
+        drvi.utils.pl.plot_latent_dimension_stats(embed, ncols=2)
+        drvi.utils.pl.plot_latent_dims_in_umap(embed)
+
+        drvi.utils.pl.plot_latent_dims_in_umap(embed)
+
+        drvi.utils.pl.plot_latent_dims_in_heatmap(embed, "cell_type", title_col="title")
+        drvi.utils.pl.show_top_differential_vars(traverse_adata, key="combined_score", score_threshold=0.0)
+
+        dimensions_interpretability = drvi.utils.tools.iterate_on_top_differential_vars(
+            traverse_adata, key="combined_score", score_threshold=0.0
+        )
+
+        sample_dim = dimensions_interpretability[0][0]
+        drvi.utils.pl.show_differential_vars_scatter_plot(
+            traverse_adata,
+            key_x="max_possible",
+            key_y="min_possible",
+            key_combined="combined_score",
+            dim_subset=[sample_dim],
+            score_threshold=0.0,
+        )
+        drvi.utils.pl.plot_relevant_genes_on_umap(
+            adata,
+            embed,
+            traverse_adata,
+            traverse_adata_key="combined_score",
+            dim_subset=[sample_dim],
+            score_threshold=0.0,
+        )

--- a/tests/utils/metrics/test_disentanglement_discrete_benchmark.py
+++ b/tests/utils/metrics/test_disentanglement_discrete_benchmark.py
@@ -14,8 +14,10 @@ class TestDiscreteDisentanglementBenchmark:
 
         return categorical_features, categorical_features_01, fit_continuous_latent, random_continuous_latent
 
-    def _general_test_pipeline(self, continuous_latent, categorical_features=None, categorical_features_01=None):
-        METRICS = ["ASC", "SPN", "SMI"]
+    def _general_test_pipeline(
+        self, continuous_latent, categorical_features=None, categorical_features_01=None, **kwargs
+    ):
+        METRICS = ["ASC", "SPN", "SMI-cont", "SMI-disc"]
         AGGREGATION_METHODS = ["LMS", "MSAS", "MSGS"]
 
         benchmark = DiscreteDisentanglementBenchmark(
@@ -24,6 +26,7 @@ class TestDiscreteDisentanglementBenchmark:
             one_hot_target=categorical_features_01,
             metrics=METRICS,
             aggregation_methods=AGGREGATION_METHODS,
+            **kwargs,
         )
         benchmark.evaluate()
         return benchmark
@@ -86,3 +89,14 @@ class TestDiscreteDisentanglementBenchmark:
 
         for metric in results_gt:
             assert np.all(results_random[metric] < results_gt[metric]), f"Results for {metric} do not match"
+
+    def test_benchmarker_with_additional_metric_params(self):
+        categorical_features, categorical_features_01, fit_continuous_latent, random_continuous_latent = (
+            self.make_test_data()
+        )
+
+        self._general_test_pipeline(
+            continuous_latent=fit_continuous_latent,
+            categorical_features=categorical_features,
+            additional_metric_params={"SMI-disc": {"n_bins": 3}},
+        )


### PR DESCRIPTION
Changes:
1. The scikit-learn implementation of MI [does not work](https://github.com/scikit-learn/scikit-learn/issues/30772) for needle-in-the-haystack scenarios (happening in our rare cell types). Accordingly, we discretize the embeddings ourselves and calculate the MI score using the information theory definition.
2. Solves a minor bug in `drvi.utils.tl.traverse_latent` (#39) 
3. Add integration tests.