### PR TITLE
Updates for release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-
 ## [Unreleased]
+
+## [0.2.1] - 2025-12-29
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning][].
 - Allow subset reconstruction
 - Allow gradient scaling in the last layer
 - Allow setting vector size after mapping in "split_map@k" and "power@k" splitting functions.
+- Add support for Python 3.14
 
 ### Removed
 - Remove restrict dependencies. To ensure compatibility with old packages run for example: `uvx --exclude-newer 2024-01-01 hatch run pytest`
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning][].
 ### Changed
 
 - Minor code improvements
+- Update to scverse template version 0.7.0
 
 ## [0.2.0] - 2025-11-24
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ While CPU-based systems are supported, GPU-powered systems are strongly recommen
 
 ## Installation
 
-You need to have Python (versions 3.10 to 3.13 supported) installed on your system. If you don't have
+You need to have Python (versions 3.10 to 3.14 supported) installed on your system. If you don't have
 Python installed, we recommend installing [uv][].
 
 There are several alternative options to install drvi:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "drvi-py"
-version = "0.2.0"
+version = "0.2.1"
 description = "Unsupervised Deep Disentangled Representation of Single-Cell Omics"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
### Added

- Add support for Python 3.13
- Allow subset reconstruction
- Allow gradient scaling in the last layer
- Allow setting vector size after mapping in "split_map@k" and "power@k" splitting functions.
- Add support for Python 3.14

### Removed
- Remove restrict dependencies. To ensure compatibility with old packages run for example: `uvx --exclude-newer 2024-01-01 hatch run pytest`

### Changed

- Minor code improvements
- Update to scverse template version 0.7.0