### PR TITLE
Add porting functionality for drvi-py to scvi-tools migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning][].
 ### Added
 
 
+## [0.2.7]
+
+### Added
+- Add `drvi.utils.port_to_scvi_tools` to migrate a trained/saved drvi-py model into a checkpoint loadable by `scvi.external.DRVI` (available in scvi-tools 1.5.0). Pure checkpoint surgery — no model is instantiated. Unsupported capabilities raise `DRVIPortError` with a link to open an issue.
+
+
 ## [0.2.6] - 2026-07-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "drvi-py"
-version = "0.2.6"
+version = "0.2.7"
 description = "Unsupervised Deep Disentangled Representation of Single-Cell Omics"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -35,6 +35,7 @@ dependencies = [
   "anndata>=0.10.2",
   "lightning>=2",
   "numpy>=1.16.1",
+  "packaging",
   "pandas>=1.2",
   "scanpy>=1.9.5",
   "scikit-learn>=1.5.1",

--- a/src/drvi/utils/__init__.py
+++ b/src/drvi/utils/__init__.py
@@ -1,10 +1,12 @@
 from . import metrics, misc
 from . import plotting as pl
 from . import tools as tl
+from .porting import port_to_scvi_tools
 
 __all__ = [
     "tl",
     "pl",
     "metrics",
     "misc",
+    "port_to_scvi_tools",
 ]

--- a/src/drvi/utils/porting.py
+++ b/src/drvi/utils/porting.py
@@ -74,7 +74,7 @@ class _DrviPy021ToDrviPy022(_Migration):
             raise DRVIPortError("'prior_init_obs' (data-initialized prior) has no equivalent")
 
 
-class _DrviPy026ToScviTools150(_Migration):
+class _DrviPy027ToScviTools150(_Migration):
     """Migration for the drvi-py -> scvi-tools hop: split value renames (split_diag->split_mask, sum->mean)."""
 
     # drvi value -> scvi-tools value; a value absent from the map is not portable.
@@ -94,12 +94,12 @@ class _DrviPy026ToScviTools150(_Migration):
 # Version lineage as a chain of hops. A saved model at ``(package, version)`` is upgraded one hop at
 # a time until it reaches the final scvi-tools version; each hop's migration adjusts params for that
 # step. Keys are ``(from_pkg, from_version, to_pkg, to_version)``; the sole terminal key is
-# ``(package, version)`` -> None. drvi-py releases go up to 0.2.6 (PyPI); DRVI ships in scvi 1.5.0.
-# Add hops for future changes.
+# ``(package, version)`` -> None. This porter ships in drvi-py 0.2.7 (the last drvi-py version); DRVI
+# then lives in scvi-tools, shipped in scvi 1.5.0. Add hops for future changes.
 _MIGRATION_CHAIN = {
     ("drvi", "0.2.1", "drvi", "0.2.2"): _DrviPy021ToDrviPy022(),
-    ("drvi", "0.2.2", "drvi", "0.2.6"): _Identity(),  # no model-kwarg changes in 0.2.2 .. 0.2.6
-    ("drvi", "0.2.6", "scvi", "1.5.0"): _DrviPy026ToScviTools150(),
+    ("drvi", "0.2.2", "drvi", "0.2.7"): _Identity(),  # no model-kwarg changes in 0.2.2 .. 0.2.7
+    ("drvi", "0.2.7", "scvi", "1.5.0"): _DrviPy027ToScviTools150(),
     ("scvi", "1.5.0"): None,  # final version; nothing to port to
 }
 

--- a/src/drvi/utils/porting.py
+++ b/src/drvi/utils/porting.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import abc
+import copy
+import logging
+import warnings
+from pathlib import Path
+
+import torch
+from packaging.version import Version
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["port_to_scvi_tools", "DRVIPorter", "DRVIPortError"]
+
+_MODEL_FILE = "model.pt"
+_NEW_ISSUE_URL = "https://github.com/theislab/drvi/issues/new"
+
+
+class DRVIPortError(RuntimeError):
+    """Raised when a drvi-py model uses a capability scvi-tools DRVI cannot reproduce.
+
+    ``reason`` is a short phrase; the full user-facing message (with the issue link) is built here.
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(
+            f"does not port: {reason}.\nIf you need to port such a model, please open an issue at "
+            f"{_NEW_ISSUE_URL} and we will look into supporting it."
+        )
+
+
+class _Migration(abc.ABC):
+    """A single version-hop transform; :meth:`apply` mutates the drvi-py ``params`` dict in place.
+
+    Which hop each migration covers is declared by :data:`_MIGRATION_CHAIN`, not by the class.
+    """
+
+    @abc.abstractmethod
+    def apply(self, params: dict) -> None: ...
+
+
+class _Identity(_Migration):
+    """No-op hop: the version bump needs no parameter change."""
+
+    def apply(self, params: dict) -> None:
+        pass
+
+
+class _DrviPy021ToDrviPy022(_Migration):
+    """Migration for drvi 0.2.2: gene_likelihood renames and prior_init_obs removal."""
+
+    VALID_GENE_LIKELIHOOD = {"nb", "pnb", "zinb", "poisson", "normal", "normal_unit_var"}
+    # old gene_likelihood -> (current name, dispersion forced by the rename).
+    RENAMES = {
+        "pnb_softmax": ("pnb", None),
+        "poisson_orig": ("poisson", None),
+        "nb_orig": ("nb", None),
+        "nb": ("nb", None),
+        "normal": ("normal_unit_var", None),
+        "normal_v": ("normal", "gene-cell"),
+        "normal_sv": ("normal", "gene"),
+    }
+
+    def apply(self, params: dict) -> None:
+        gene_likelihood = params.get("gene_likelihood")
+        if gene_likelihood is not None and gene_likelihood not in self.VALID_GENE_LIKELIHOOD:
+            if gene_likelihood not in self.RENAMES:
+                raise DRVIPortError(f"gene_likelihood '{gene_likelihood}' was dropped in drvi 0.2.2")
+            params["gene_likelihood"], forced_dispersion = self.RENAMES[gene_likelihood]
+            if forced_dispersion is not None:
+                params["dispersion"] = forced_dispersion
+        if params.pop("prior_init_obs", None) is not None:
+            raise DRVIPortError("'prior_init_obs' (data-initialized prior) has no equivalent")
+
+
+class _DrviPy026ToScviTools150(_Migration):
+    """Migration for the drvi-py -> scvi-tools hop: split value renames (split_diag->split_mask, sum->mean)."""
+
+    # drvi value -> scvi-tools value; a value absent from the map is not portable.
+    SPLIT_METHOD = {"split_map": "split_map", "split_diag": "split_mask"}
+    SPLIT_AGGREGATION = {"sum": "mean", "logsumexp": "logsumexp"}
+
+    def apply(self, params: dict) -> None:
+        for key, mapping in (("split_method", self.SPLIT_METHOD), ("split_aggregation", self.SPLIT_AGGREGATION)):
+            value = params.get(key)
+            if value is None:
+                continue
+            if value not in mapping:
+                raise DRVIPortError(f"{key} '{value}'")
+            params[key] = mapping[value]
+
+
+# Version lineage as a chain of hops. A saved model at ``(package, version)`` is upgraded one hop at
+# a time until it reaches the final scvi-tools version; each hop's migration adjusts params for that
+# step. Keys are ``(from_pkg, from_version, to_pkg, to_version)``; the sole terminal key is
+# ``(package, version)`` -> None. drvi-py releases go up to 0.2.6 (PyPI); DRVI ships in scvi 1.5.0.
+# Add hops for future changes.
+_MIGRATION_CHAIN = {
+    ("drvi", "0.2.1", "drvi", "0.2.2"): _DrviPy021ToDrviPy022(),
+    ("drvi", "0.2.2", "drvi", "0.2.6"): _Identity(),  # no model-kwarg changes in 0.2.2 .. 0.2.6
+    ("drvi", "0.2.6", "scvi", "1.5.0"): _DrviPy026ToScviTools150(),
+    ("scvi", "1.5.0"): None,  # final version; nothing to port to
+}
+
+
+class DRVIPorter:
+    """Transforms one drvi-py DRVI checkpoint into a scvi-tools ``scvi.external.DRVI`` checkpoint.
+
+    Pure surgery on the loaded ``model.pt`` dict: parameters and architecture are read (the
+    state-dict shapes are the source of truth), unportable capabilities are rejected, and the
+    state-dict, ``init_params_`` and ``registry_`` are rewritten to scvi-tools' layout.
+    """
+
+    # param -> (values scvi-tools can reproduce, reason phrase); any other value is not portable.
+    REQUIRED_VALUES = {
+        "covariate_modeling_strategy": ({"one_hot"}, "models categorical covariates as one-hot only"),
+        "var_activation": ({"exp"}, "uses the exp variance activation only"),
+        "prior": ({"normal"}, "supports the standard normal prior only"),
+    }
+    # param -> default; a non-default value only affects training and is dropped with a warning.
+    TRAINING_ONLY = {
+        "input_dropout_rate": 0.0,
+        "fill_in_the_blanks_ratio": 0.0,
+        "reconstruction_strategy": "dense",
+        "last_layer_gradient_scale": 1.0,
+    }
+    # state-dict entries with no scvi-tools counterpart (param-free / training-only).
+    DROPPED_STATE_PREFIXES = ("latent_stats.", "mi_metric.", "prior.", "decoder.last_layer_gradient_scaler")
+    # drvi mean_activation base name -> torch.nn class name (None == identity / no-op).
+    MEAN_ACTIVATION = {
+        "identity": None,
+        "relu": "ReLU",
+        "gelu": "GELU",
+        "elu": "ELU",
+        "celu": "CELU",
+        "leaky_relu": "LeakyReLU",
+    }
+    ACTIVATION_FN = {"ELU": "elu", "ReLU": "relu"}
+
+    def __init__(self, checkpoint: dict):
+        self._var_names = checkpoint["var_names"]
+        self._attr = checkpoint["attr_dict"]
+        self._old_sd = checkpoint["model_state_dict"]
+        self._old_registry = self._attr.get("registry_", {})
+
+        self.params = self._parse_params()
+        self.arch = self._infer_architecture()
+        forced_dispersion = self.params.get("dispersion")
+        if forced_dispersion is not None:
+            self.arch["dispersion"] = forced_dispersion
+        self._check_capabilities()
+
+        self.mean_activation = self._translate_mean_activation(self.params.get("mean_activation"))
+        self.mean_activation_wrapped = self.mean_activation is not None
+
+    @classmethod
+    def from_path(cls, model_file: Path) -> DRVIPorter:
+        return cls(torch.load(model_file, map_location="cpu", weights_only=False))
+
+    def build_checkpoint(self) -> dict:
+        """Assemble the scvi-tools ``model.pt`` dictionary."""
+        attr = copy.deepcopy(self._attr)
+        attr["init_params_"] = self._init_params()
+        attr["registry_"] = self._registry()
+        attr["is_trained_"] = True
+        return {
+            "model_state_dict": self._state_dict(),
+            "var_names": self._var_names,
+            "attr_dict": attr,
+        }
+
+    # -- parsing / capability checks ---------------------------------------------------------------
+    def _parse_params(self) -> dict:
+        """Flatten drvi ``init_params_`` and apply the version migrations."""
+        init = self._attr.get("init_params_", {})
+        params = dict(init.get("non_kwargs", {}))
+        for inner in init.get("kwargs", {}).values():
+            if isinstance(inner, dict):  # >=0.2 nests architecture args under kwargs["model_kwargs"]
+                params.update(inner)
+        for deprecated in ("categorical_covariates", "batch_key"):
+            params.pop(deprecated, None)
+
+        # Walk the version chain from the saved model up to the final version, applying each hop.
+        pkg = "drvi"
+        version = Version(self._old_registry.get("drvi_version") or "0.1.0")
+        hops = sorted((k for k in _MIGRATION_CHAIN if len(k) == 4), key=lambda k: Version(k[1]))
+        while hop := next((h for h in hops if h[0] == pkg and version <= Version(h[1])), None):
+            _MIGRATION_CHAIN[hop].apply(params)
+            pkg, version = hop[2], Version(hop[3])
+        return params
+
+    def _check_capabilities(self) -> None:
+        for param, (allowed, reason) in self.REQUIRED_VALUES.items():
+            value = self.params.get(param)
+            if value is not None and value not in allowed:
+                raise DRVIPortError(f"{param}={value!r}: scvi-tools DRVI {reason}")
+        if any(".emb_list." in k or k.startswith("shared_covariate_emb") for k in self._old_sd):
+            raise DRVIPortError("the model uses learned covariate embeddings")
+        # scvi-tools DecoderDRVI hardcodes dropout_rate=0, so decoder dropout can't be reproduced.
+        if self.params.get("decoder_dropout_rate", 0.0):
+            raise DRVIPortError(f"decoder dropout (decoder_dropout_rate={self.params['decoder_dropout_rate']})")
+        dropped = [k for k, default in self.TRAINING_ONLY.items() if self.params.get(k, default) != default]
+        if dropped:
+            warnings.warn(
+                "Dropping drvi-py training-only settings (they do not change the ported model's "
+                f"inference): {', '.join(dropped)}.",
+                stacklevel=3,
+            )
+
+    # -- value translations ------------------------------------------------------------------------
+    def _translate_mean_activation(self, value) -> str | None:
+        """Translate a drvi ``mean_activation`` to a scvi-tools value; None == identity.
+
+        drvi accepts ``"identity"``, ``"relu"``, ``"gelu"``, ``"leaky_relu[_slope]"``,
+        ``"elu[_alpha]"``, ``"celu[_alpha]"``, or a callable. Strings are mapped to their torch.nn
+        spelling (with the optional argument preserved); a callable/instance is passed through,
+        which scvi-tools' ``_resolve_mean_activation`` accepts directly.
+        """
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return value
+        for base in sorted(self.MEAN_ACTIVATION, key=len, reverse=True):  # longest first (leaky_relu)
+            if value == base or value.startswith(base + "_"):
+                torch_name = self.MEAN_ACTIVATION[base]
+                if torch_name is None:  # identity
+                    return None
+                arg = value[len(base) :].lstrip("_")
+                return f"{torch_name}_{arg}" if arg else torch_name
+        raise DRVIPortError(f"mean_activation '{value}' has no scvi-tools equivalent")
+
+    def _activation_fn(self):
+        """Resolve the hidden-layer activation shared by scvi-tools' encoder and decoder.
+
+        drvi keeps ``activation_fn`` (a torch.nn class, default ``nn.ELU``) in ``extra_encoder_kwargs``
+        and ``extra_decoder_kwargs`` separately; scvi-tools uses a single ``activation_fn`` for both,
+        so differing encoder/decoder activations cannot be reproduced. A class scvi-tools does not
+        spell as a string is passed through (its ``_resolve_activation`` accepts a class directly).
+        """
+        resolved = {
+            self._to_activation_value(self.params[key]["activation_fn"])
+            for key in ("extra_encoder_kwargs", "extra_decoder_kwargs")
+            if isinstance(self.params.get(key), dict) and self.params[key].get("activation_fn") is not None
+        }
+        if not resolved:
+            return "elu"  # drvi's default hidden activation
+        if len(resolved) > 1:
+            raise DRVIPortError("the encoder and decoder use different hidden activations")
+        return resolved.pop()
+
+    def _to_activation_value(self, activation):
+        if isinstance(activation, str):
+            return activation.lower()
+        return self.ACTIVATION_FN.get(getattr(activation, "__name__", None), activation)
+
+    # -- architecture inference (state-dict shapes are the source of truth) -------------------------
+    @staticmethod
+    def _fc_layer_indices(state_dict: dict, prefix: str) -> list[int]:
+        """Sorted layer indices ``i`` present as ``{prefix}.fc_layers.Layer {i}.0.weight``."""
+        marker = f"{prefix}.fc_layers.Layer "
+        return sorted(
+            int(key[len(marker) : key.index(".", len(marker))])
+            for key in state_dict
+            if key.startswith(marker) and key.endswith(".0.weight")
+        )
+
+    def _infer_architecture(self) -> dict:
+        state = self._old_sd
+        enc = "z_encoder.encoder"
+        enc_layers = self._fc_layer_indices(state, enc)
+        if not enc_layers:
+            raise DRVIPortError("unrecognized checkpoint (no encoder layers found)")
+
+        enc_widths = [state[f"{enc}.fc_layers.Layer {i}.0.weight"].shape[0] for i in enc_layers]
+        n_input = len(self._var_names)
+        if state[f"{enc}.fc_layers.Layer {enc_layers[0]}.0.weight"].shape[1] != n_input:
+            raise DRVIPortError("the encoder consumes covariates (encode_covariates=True)")
+        n_latent = state["z_encoder.mean_encoder.fc_layers.Layer 0.0.weight"].shape[0]
+
+        dec = "decoder.px_shared_decoder"
+        dec_layers = self._fc_layer_indices(state, dec)
+        dec_weights = [state[f"{dec}.fc_layers.Layer {i}.0.weight"] for i in dec_layers]
+        hidden_shared = [w.dim() == 2 for w in dec_weights]  # 2-D nn.Linear shared, 3-D per-split
+        dec_widths = [(w.shape[-2] if w.dim() == 3 else w.shape[0]) for w in dec_weights]
+
+        widths = set(enc_widths + dec_widths)
+        if len(widths) != 1:
+            raise DRVIPortError(f"encoder/decoder layers are not all one width ({sorted(widths)})")
+        if len(enc_layers) != len(dec_layers):
+            raise DRVIPortError("encoder and decoder have different layer counts")
+
+        split_weight = state.get("decoder.split_transformation_weight")  # (n_split, in, out)
+        head_shared = state["decoder.params_nets.mean.fc_layers.Layer 0.0.weight"].dim() == 2
+        return {
+            "n_input": n_input,
+            "n_latent": n_latent,
+            "n_hidden": widths.pop(),
+            "n_layers": len(enc_layers),
+            "n_split": split_weight.shape[0] if split_weight is not None else n_latent,
+            "n_split_output": split_weight.shape[2] if split_weight is not None else n_latent,
+            "split_method": "split_map" if split_weight is not None else "split_diag",
+            "dispersion": self._infer_dispersion(),
+            "decoder_reuse_weights": self._reuse_weights(hidden_shared, head_shared),
+        }
+
+    def _infer_dispersion(self) -> str:
+        state = self._old_sd
+        if "decoder.params_nets.r" in state:
+            return "gene"
+        if "decoder.params_nets.r.weight" in state:
+            return "gene-batch"
+        if any(k.startswith("decoder.params_nets.r.fc_layers.") for k in state):
+            return "gene-cell"
+        raise DRVIPortError("could not determine dispersion from the checkpoint")
+
+    @staticmethod
+    def _reuse_weights(hidden_shared: list[bool], head_shared: bool) -> str:
+        pure = {
+            (True, True): "everywhere",
+            (True, False): "hidden",
+            (False, True): "last",
+            (False, False): "nowhere",
+        }
+        if all(hidden_shared) or not any(hidden_shared):
+            return pure[all(hidden_shared), head_shared]
+        if not hidden_shared[0] and all(hidden_shared[1:]) and head_shared:
+            return "hidden_except_first"
+        raise DRVIPortError("the decoder weight-sharing pattern is not representable")
+
+    # -- init_params_ / registry_ ------------------------------------------------------------------
+    def _init_params(self) -> dict:
+        # split_method / split_aggregation were already translated to scvi-tools' spelling by the
+        # drvi-py -> scvi-tools migration; the defaults below are identical in both.
+        non_kwargs = {
+            "n_latent": self.arch["n_latent"],
+            "n_split_latent": self.arch["n_split"],
+            "split_method": self.params.get("split_method", "split_map"),
+            "split_aggregation": self.params.get("split_aggregation", "logsumexp"),
+            "gene_likelihood": self.params.get("gene_likelihood", "pnb"),  # drvi's default
+        }
+        kwargs = {
+            "n_hidden": self.arch["n_hidden"],
+            "n_layers": self.arch["n_layers"],
+            "dispersion": self.arch["dispersion"],
+            "decoder_reuse_weights": self.arch["decoder_reuse_weights"],
+            "mean_activation": self.mean_activation,
+            "activation_fn": self._activation_fn(),
+            "use_batch_norm": self.params.get("use_batch_norm", "none"),
+            "use_layer_norm": self.params.get("use_layer_norm", "both"),
+            "deeply_inject_covariates": self.params.get("deeply_inject_covariates", False),
+            "use_observed_lib_size": True,
+            "batch_representation": "one-hot",
+        }
+        if self.arch["split_method"] == "split_map" and self.arch["n_split_output"] != self.arch["n_latent"]:
+            kwargs["n_split_output"] = self.arch["n_split_output"]
+        return {"non_kwargs": non_kwargs, "kwargs": {"kwargs": kwargs}}
+
+    def _registry(self) -> dict:
+        registry = copy.deepcopy(self._old_registry)
+        registry["model_name"] = "DRVI"
+        registry["setup_method_name"] = "setup_anndata"
+        setup_args = dict(registry.get("setup_args", {}))
+        setup_args.pop("is_count_data", None)  # drvi-only kwarg; SCVI.setup_anndata rejects it
+        setup_args.setdefault("size_factor_key", None)  # SCVI reads this key unconditionally
+        setup_args.setdefault("batch_key", None)
+        registry["setup_args"] = setup_args
+        return registry
+
+    # -- state_dict --------------------------------------------------------------------------------
+    @staticmethod
+    def _transpose_per_split(weight: torch.Tensor) -> torch.Tensor:
+        """Convert a per-split weight to the ``stacked_linear`` layout, leaving shared weights untouched.
+
+        drvi's ``StackedLinearLayer`` stores ``(n_split, in, out)``; the ``stacked_linear`` package
+        used by scvi-tools stores ``(n_split, out, in)``. Only per-split weights are 3-D; shared
+        (2-D) weights and biases are returned unchanged.
+        """
+        return weight.transpose(-1, -2).contiguous() if weight.dim() == 3 else weight
+
+    def _rename_rules(self) -> list[tuple[str, str, bool]]:
+        """``(source prefix, destination prefix, transpose per-split weights)`` for direct copies."""
+        mean_dst = "z_encoder.mean_encoder." + ("0." if self.mean_activation_wrapped else "")
+        return [
+            ("z_encoder.encoder.fc_layers.", "z_encoder.encoder.fc_layers.", False),
+            ("z_encoder.mean_encoder.fc_layers.Layer 0.0.", mean_dst, False),
+            ("z_encoder.var_encoder.fc_layers.Layer 0.0.", "z_encoder.var_encoder.", False),
+            ("decoder.split_transformation_weight", "decoder.split_transform.weight", True),
+            ("decoder.px_shared_decoder.fc_layers.", "decoder.px_decoder.fc_layers.", True),
+            ("decoder.params_nets.mean.fc_layers.Layer 0.0.", "decoder.px_scale_decoder.", True),
+        ]
+
+    def _is_dropped(self, key: str) -> bool:
+        return (
+            key == "pyro_param_store"  # scvi's load pops this; it is not an nn parameter
+            or key.startswith("decoder.params_nets.r")  # dispersion, handled by _dispersion_params
+            or any(key.startswith(prefix) for prefix in self.DROPPED_STATE_PREFIXES)
+        )
+
+    def _state_dict(self) -> dict:
+        new_sd = self._dispersion_params()
+        rules = self._rename_rules()
+        for key, value in self._old_sd.items():
+            if self._is_dropped(key):
+                continue
+            for src, dst, transpose in rules:
+                if key.startswith(src):
+                    new_sd[dst + key[len(src) :]] = self._transpose_per_split(value) if transpose else value
+                    break
+            else:
+                raise DRVIPortError(f"unexpected checkpoint parameter '{key}'")
+        new_sd.update(self._library_encoder_params())
+        return new_sd
+
+    def _dispersion_params(self) -> dict:
+        # drvi feeds ``r = 1.0 + param`` to its noise model; scvi-tools' generative uses the stored
+        # value directly, so the +1.0 offset is folded in here.
+        return {
+            "gene": self._dispersion_gene,
+            "gene-batch": self._dispersion_gene_batch,
+            "gene-cell": self._dispersion_gene_cell,
+        }[self.arch["dispersion"]]()
+
+    def _dispersion_gene(self) -> dict:
+        return {"px_r": self._old_sd["decoder.params_nets.r"] + 1.0}
+
+    def _dispersion_gene_batch(self) -> dict:
+        weight = self._old_sd["decoder.params_nets.r.weight"]  # (n_genes, n_batch)
+        bias = self._old_sd["decoder.params_nets.r.bias"]  # (n_genes,)
+        # (W + b) + 1 matches drvi's runtime add-order exactly (scvi does linear(one_hot, px_r)).
+        return {"px_r": (weight + bias.unsqueeze(1)) + 1.0}
+
+    def _dispersion_gene_cell(self) -> dict:
+        head = "decoder.params_nets.r.fc_layers.Layer 0.0."
+        return {
+            "decoder.px_r_decoder.weight": self._transpose_per_split(self._old_sd[head + "weight"]),
+            "decoder.px_r_decoder.bias": self._old_sd[head + "bias"] + 1.0,
+        }
+
+    def _library_encoder_params(self) -> dict:
+        # scvi's VAE always has a library encoder; DRVI never reads it (observed library size), but a
+        # strict load_state_dict still needs the keys. Zeros of the right shape satisfy it.
+        kw = {"dtype": self._old_sd["z_encoder.encoder.fc_layers.Layer 0.0.weight"].dtype}
+        n_hidden, n_input = self.arch["n_hidden"], self.arch["n_input"]
+        return {
+            "l_encoder.encoder.fc_layers.Layer 0.0.weight": torch.zeros(n_hidden, n_input, **kw),
+            "l_encoder.encoder.fc_layers.Layer 0.0.bias": torch.zeros(n_hidden, **kw),
+            "l_encoder.mean_encoder.weight": torch.zeros(1, n_hidden, **kw),
+            "l_encoder.mean_encoder.bias": torch.zeros(1, **kw),
+            "l_encoder.var_encoder.weight": torch.zeros(1, n_hidden, **kw),
+            "l_encoder.var_encoder.bias": torch.zeros(1, **kw),
+        }
+
+
+def _resolve_model_file(path: Path) -> Path:
+    if path.is_dir():
+        return path / _MODEL_FILE
+    if path.is_file():
+        return path
+    raise FileNotFoundError(f"No DRVI model found at {path!s}.")
+
+
+def port_to_scvi_tools(
+    source: str | Path,
+    dest: str | Path | None = None,
+    *,
+    overwrite: bool = False,
+) -> str:
+    """Port a drvi-py DRVI checkpoint to a scvi-tools ``scvi.external.DRVI`` checkpoint.
+
+    Reads the drvi-py ``model.pt`` at ``source``, rewrites it, and writes a new ``model.pt`` under
+    ``dest`` that can be loaded with :meth:`scvi.external.DRVI.load`. The source is never modified,
+    and an existing ``dest`` is never overwritten unless ``overwrite=True``.
+
+    No model is instantiated: this is a pure checkpoint transformation. To load the result you still
+    need an ``AnnData`` whose ``var_names`` match the trained genes and whose ``obs`` has the
+    covariate columns the model was set up with.
+
+    Parameters
+    ----------
+    source
+        Path to the drvi-py model directory (containing ``model.pt``) or the ``model.pt`` file.
+    dest
+        Output model directory. Defaults to ``"{source_dir}_scvi_tools"``.
+    overwrite
+        Overwrite ``dest`` if it already exists (default ``False``).
+
+    Returns
+    -------
+    The path to the created output model directory.
+
+    Raises
+    ------
+    DRVIPortError
+        If the model uses a capability scvi-tools DRVI cannot reproduce.
+    """
+    model_file = _resolve_model_file(Path(source).expanduser())
+    source_dir = model_file.parent
+
+    dest = Path(dest).expanduser() if dest is not None else source_dir.parent / f"{source_dir.name}_scvi_tools"
+    if dest.exists() and not overwrite:
+        raise FileExistsError(f"Destination {dest!s} already exists. Pass a different `dest` or `overwrite=True`.")
+
+    checkpoint = DRVIPorter.from_path(model_file).build_checkpoint()
+    dest.mkdir(parents=True, exist_ok=overwrite)
+    torch.save(checkpoint, dest / _MODEL_FILE)
+    logger.info("Ported DRVI model %s -> %s", source_dir, dest)
+    return str(dest)

--- a/tests/utils/test_porting.py
+++ b/tests/utils/test_porting.py
@@ -1,0 +1,273 @@
+"""Tests for :func:`drvi.utils.port_to_scvi_tools` (drvi-py -> scvi-tools checkpoint migration).
+
+These validate the checkpoint transformation itself (key remapping, value transforms, ``init_params_``
+and ``registry_`` rewriting) without importing scvi-tools. An end-to-end numerical-equivalence check
+against ``scvi.external.DRVI`` lives outside the drvi-py test suite (it needs scvi-tools installed).
+"""
+
+import copy
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from drvi.model import DRVI
+from drvi.utils import port_to_scvi_tools
+from drvi.utils.porting import DRVIPorter, DRVIPortError
+
+
+def _make_adata(n=200, g=50, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.poisson(1.0, size=(n, g)).astype(np.float32)
+    adata = ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(
+            {
+                "batch": [f"b{i % 2}" for i in range(n)],
+                "cov": [f"c{i % 3}" for i in range(n)],
+            },
+            index=[f"cell_{i}" for i in range(n)],
+        ),
+        var=pd.DataFrame(index=[f"gene_{i}" for i in range(g)]),
+    )
+    adata.layers["counts"] = X.copy()
+    return adata
+
+
+def _train_and_save(tmp_path, name, **model_kwargs):
+    adata = _make_adata()
+    DRVI.setup_anndata(adata, layer="counts", batch_key="batch", categorical_covariate_keys=["cov"])
+    model = DRVI(adata, **model_kwargs)
+    model.train(max_epochs=2, accelerator="cpu", batch_size=128, train_size=0.9)
+    out = str(tmp_path / name)
+    model.save(out, overwrite=True)
+    return out
+
+
+def _load_sd(model_dir):
+    ckpt = torch.load(f"{model_dir}/model.pt", map_location="cpu", weights_only=False)
+    return ckpt["model_state_dict"], ckpt["attr_dict"], list(ckpt["var_names"])
+
+
+class TestPortToScviTools:
+    def test_default_model_end_to_end(self, tmp_path):
+        src = _train_and_save(tmp_path, "src_default")
+        old_sd, _, var_names = _load_sd(src)
+
+        dest = port_to_scvi_tools(src)  # default dest = "{src}_scvi_tools"
+        assert dest == f"{src}_scvi_tools"
+        new_sd, new_attr, new_var = _load_sd(dest)
+
+        # var_names preserved
+        assert new_var == var_names
+
+        # --- key remapping: old-only prefixes gone, new names present ---
+        for banned in (
+            "decoder.params_nets",
+            "decoder.px_shared_decoder",
+            "decoder.split_transformation_weight",
+            "z_encoder.mean_encoder.fc_layers",
+            "z_encoder.var_encoder.fc_layers",
+            "latent_stats",
+            "mi_metric",
+            "prior.",
+        ):
+            assert not any(k.startswith(banned) for k in new_sd), banned
+
+        # --- encoder body: identity ---
+        for k, v in old_sd.items():
+            if k.startswith("z_encoder.encoder.fc_layers."):
+                assert torch.equal(new_sd[k], v)
+
+        # --- mean/var encoder un-nested (FCLayers -> plain Linear) ---
+        assert torch.equal(
+            new_sd["z_encoder.mean_encoder.weight"],
+            old_sd["z_encoder.mean_encoder.fc_layers.Layer 0.0.weight"],
+        )
+        assert torch.equal(
+            new_sd["z_encoder.var_encoder.bias"],
+            old_sd["z_encoder.var_encoder.fc_layers.Layer 0.0.bias"],
+        )
+
+        # --- split transform: transposed (n_split, in, out) -> (n_split, out, in) ---
+        assert torch.equal(
+            new_sd["decoder.split_transform.weight"],
+            old_sd["decoder.split_transformation_weight"].transpose(-1, -2),
+        )
+
+        # --- scale head un-nested ---
+        assert torch.equal(
+            new_sd["decoder.px_scale_decoder.weight"],
+            old_sd["decoder.params_nets.mean.fc_layers.Layer 0.0.weight"],
+        )
+
+        # --- dispersion "gene": px_r = old r + 1.0 (drvi's r = 1.0 + param; scvi uses px_r directly) ---
+        assert torch.allclose(new_sd["px_r"], old_sd["decoder.params_nets.r"] + 1.0)
+
+        # --- synthesized (unused) library encoder present and zeroed ---
+        for k in (
+            "l_encoder.encoder.fc_layers.Layer 0.0.weight",
+            "l_encoder.encoder.fc_layers.Layer 0.0.bias",
+            "l_encoder.mean_encoder.weight",
+            "l_encoder.var_encoder.weight",
+        ):
+            assert k in new_sd
+            assert torch.count_nonzero(new_sd[k]) == 0
+
+        # --- init_params_ rewritten to scvi-tools DRVI signature ---
+        non_kwargs = new_attr["init_params_"]["non_kwargs"]
+        assert set(non_kwargs) == {
+            "n_latent",
+            "n_split_latent",
+            "split_method",
+            "split_aggregation",
+            "gene_likelihood",
+        }
+        assert non_kwargs["split_method"] == "split_map"
+        assert non_kwargs["split_aggregation"] == "logsumexp"
+        kwargs = new_attr["init_params_"]["kwargs"]["kwargs"]
+        assert kwargs["dispersion"] == "gene"
+        assert kwargs["decoder_reuse_weights"] == "everywhere"
+        assert kwargs["use_observed_lib_size"] is True
+        assert kwargs["batch_representation"] == "one-hot"
+
+        # --- registry cleaned for scvi-tools setup_anndata ---
+        registry = new_attr["registry_"]
+        assert registry["model_name"] == "DRVI"
+        assert registry["setup_method_name"] == "setup_anndata"
+        assert "is_count_data" not in registry["setup_args"]
+        assert registry["setup_args"]["size_factor_key"] is None
+        assert new_attr["is_trained_"] is True
+
+    def test_no_weight_sharing_transposes_head(self, tmp_path):
+        src = _train_and_save(tmp_path, "src_nowhere", decoder_reuse_weights="nowhere")
+        old_sd, _, _ = _load_sd(src)
+        dest = port_to_scvi_tools(src)
+        new_sd, new_attr, _ = _load_sd(dest)
+
+        old_head = old_sd["decoder.params_nets.mean.fc_layers.Layer 0.0.weight"]
+        assert old_head.dim() == 3  # per-split StackedLinearLayer weight
+        assert torch.equal(new_sd["decoder.px_scale_decoder.weight"], old_head.transpose(-1, -2))
+        assert new_attr["init_params_"]["kwargs"]["kwargs"]["decoder_reuse_weights"] == "hidden"
+
+    def test_gene_batch_dispersion_folds_offset(self, tmp_path):
+        # scvi computes gene-batch dispersion as linear(one_hot(batch), px_r) with no bias/offset,
+        # so the old Linear weight, bias, and drvi's +1.0 must fuse into one px_r matrix.
+        src = _train_and_save(tmp_path, "src_gb", dispersion="gene-batch")
+        old_sd, _, _ = _load_sd(src)
+        dest = port_to_scvi_tools(src)
+        new_sd, new_attr, _ = _load_sd(dest)
+
+        w = old_sd["decoder.params_nets.r.weight"]  # (n_genes, n_batch)
+        b = old_sd["decoder.params_nets.r.bias"]  # (n_genes,)
+        # folded in drvi's runtime add-order (W + b) + 1 -> bit-identical to drvi's forward
+        assert torch.equal(new_sd["px_r"], (w + b.unsqueeze(1)) + 1.0)
+        assert not any(k.startswith("decoder.px_r_decoder") for k in new_sd)
+        assert new_attr["init_params_"]["kwargs"]["kwargs"]["dispersion"] == "gene-batch"
+
+    def test_gene_cell_dispersion_head_raw(self, tmp_path):
+        # scvi adds drvi's +1.0 after split-aggregation, so the per-cell head is copied raw.
+        src = _train_and_save(tmp_path, "src_gc", dispersion="gene-cell")
+        old_sd, _, _ = _load_sd(src)
+        dest = port_to_scvi_tools(src)
+        new_sd, new_attr, _ = _load_sd(dest)
+
+        old_w = old_sd["decoder.params_nets.r.fc_layers.Layer 0.0.weight"]
+        old_b = old_sd["decoder.params_nets.r.fc_layers.Layer 0.0.bias"]
+        expected_w = old_w.transpose(-1, -2) if old_w.dim() == 3 else old_w
+        assert torch.equal(new_sd["decoder.px_r_decoder.weight"], expected_w)
+        # +1.0 folded into the head bias (commutes through split aggregation)
+        assert torch.allclose(new_sd["decoder.px_r_decoder.bias"], old_b + 1.0)
+        assert "px_r" not in new_sd  # gene-cell has no module-level dispersion parameter
+        assert new_attr["init_params_"]["kwargs"]["kwargs"]["dispersion"] == "gene-cell"
+
+    def test_does_not_overwrite(self, tmp_path):
+        src = _train_and_save(tmp_path, "src_ow")
+        dest = str(tmp_path / "explicit_dest")
+        port_to_scvi_tools(src, dest)
+        with pytest.raises(FileExistsError):
+            port_to_scvi_tools(src, dest)
+        # overwrite=True succeeds
+        port_to_scvi_tools(src, dest, overwrite=True)
+
+    def test_raises_on_removed_capability(self, tmp_path):
+        """A capability with no scvi-tools equivalent must raise DRVIPortError, not silently port."""
+        src = _train_and_save(tmp_path, "src_cap")
+        ckpt = torch.load(f"{src}/model.pt", map_location="cpu", weights_only=False)
+
+        # unsupported split_aggregation
+        bad = copy.deepcopy(ckpt)
+        bad["attr_dict"]["init_params_"]["kwargs"]["model_kwargs"] = {"split_aggregation": "max"}
+        bad_dir = tmp_path / "bad_agg"
+        bad_dir.mkdir()
+        torch.save(bad, bad_dir / "model.pt")
+        with pytest.raises(DRVIPortError):
+            port_to_scvi_tools(str(bad_dir))
+
+        # unsupported covariate strategy
+        bad2 = copy.deepcopy(ckpt)
+        bad2["attr_dict"]["init_params_"]["kwargs"]["model_kwargs"] = {"covariate_modeling_strategy": "emb"}
+        bad2_dir = tmp_path / "bad_cov"
+        bad2_dir.mkdir()
+        torch.save(bad2, bad2_dir / "model.pt")
+        with pytest.raises(DRVIPortError):
+            port_to_scvi_tools(str(bad2_dir))
+
+        # decoder dropout: scvi-tools DRVI's decoder is dropout-free -> must raise
+        bad3 = copy.deepcopy(ckpt)
+        bad3["attr_dict"]["init_params_"]["kwargs"]["model_kwargs"] = {"decoder_dropout_rate": 0.1}
+        bad3_dir = tmp_path / "bad_dec_dropout"
+        bad3_dir.mkdir()
+        torch.save(bad3, bad3_dir / "model.pt")
+        with pytest.raises(DRVIPortError, match="decoder dropout"):
+            port_to_scvi_tools(str(bad3_dir))
+
+
+class TestActivationCoverage:
+    """Every drvi activation (mean and FCLayers) maps to a scvi-tools value or is rejected."""
+
+    @pytest.fixture
+    def porter(self):
+        return DRVIPorter.__new__(DRVIPorter)  # bare instance; the methods use only class data
+
+    @pytest.mark.parametrize(
+        ("drvi_value", "expected"),
+        [
+            ("identity", None),
+            ("relu", "ReLU"),
+            ("gelu", "GELU"),
+            ("leaky_relu", "LeakyReLU"),
+            ("leaky_relu_0.2", "LeakyReLU_0.2"),
+            ("elu", "ELU"),
+            ("elu_0.5", "ELU_0.5"),
+            ("celu", "CELU"),
+            ("celu_0.1", "CELU_0.1"),
+        ],
+    )
+    def test_mean_activation_translation(self, porter, drvi_value, expected):
+        assert porter._translate_mean_activation(drvi_value) == expected
+
+    def test_mean_activation_callable_passthrough(self, porter):
+        assert porter._translate_mean_activation(torch.nn.ReLU) is torch.nn.ReLU
+
+    def test_mean_activation_unknown_raises(self, porter):
+        with pytest.raises(DRVIPortError):
+            porter._translate_mean_activation("swish")
+
+    def test_activation_fn(self, porter):
+        porter.params = {"extra_encoder_kwargs": {"activation_fn": torch.nn.ELU}}
+        assert porter._activation_fn() == "elu"  # known class -> clean string
+        porter.params = {"extra_encoder_kwargs": {"activation_fn": torch.nn.GELU}}
+        assert porter._activation_fn() is torch.nn.GELU  # other class -> passed through
+        porter.params = {}
+        assert porter._activation_fn() == "elu"  # drvi FCLayers default
+
+    def test_activation_fn_encoder_decoder_mismatch_raises(self, porter):
+        porter.params = {
+            "extra_encoder_kwargs": {"activation_fn": torch.nn.ELU},
+            "extra_decoder_kwargs": {"activation_fn": torch.nn.ReLU},
+        }
+        with pytest.raises(DRVIPortError, match="different hidden activations"):
+            porter._activation_fn()


### PR DESCRIPTION
## Motivation

DRVI's PyTorch model has moved out of drvi-py into scvi-tools (`scvi.external.DRVI`). Users who trained models with drvi-py need a way to keep using them once drvi-py drops its module code (version >= 0.3.0). This PR adds a checkpoint-migration utility that converts a saved drvi-py model (`model.pt`) into one loadable by `scvi.external.DRVI.load(...)`.

## How to port
Minimal code:

```python
import scvi
from drvi

new_dir = drvi.utils.port_to_scvi_tools("path/to/old_model", "path/to/new_model")
model = scvi.external.DRVI.load(new_dir, adata)
```

- **Pure checkpoint surgery.** Reads the old `model.pt` dict, rewrites `model_state_dict`, `init_params_` and `registry_`, and writes a new `model.pt`. It never instantiates an `nn.Module` and imports neither drvi-py's nor scvi-tools' model classes — so it keeps working even after drvi-py removes its module (only `torch` + `packaging` are needed).
- **Non-destructive.** The source is never modified; an existing `dest` is never overwritten unless `overwrite=True`.


## Additional information (🤖 Generated with Claude Code)

### Key transformations

- **State-dict remap:** `StackedLinearLayer` / `split_transformation_weight` layout `(n_split, in, out)` → scvi's `(n_split, out, in)` (transpose of every per-split weight); encoder mean/var un-nested from `FCLayers` to plain `Linear`; `px_shared_decoder → px_decoder`, `params_nets.mean → px_scale_decoder`; synthesized zeroed `l_encoder.*` (scvi's VAE always has a library encoder; strict load requires the keys, but they're unused since DRVI uses the observed library size).
- **Dispersion offset** (`r = 1.0 + param` in drvi vs `px_r` used directly in scvi): folded correctly for `gene`, `gene-batch`, and `gene-cell`, matching drvi's runtime add-order for bit-exactness where possible.
- **Version migrations** as a small chain (one function per transition, e.g. `drvi_py_0.2.1 → 0.2.2` gene-likelihood renames / `prior_init_obs` removal, and the `drvi_py → scvi_tools` split-value renames). Adding a future breaking change is one function + one table entry.
- **Registry fixes** so scvi's `setup_anndata` accepts it on load (drops `is_count_data`, adds `size_factor_key`, sets `model_name="DRVI"`).
- **Capability gate:** raises `DRVIPortError` for features scvi-tools DRVI cannot reproduce (learned covariate embeddings, non-normal prior, unsupported split methods/aggregations, non-uniform layer widths, decoder dropout, dropped gene-likelihoods); warns for training-only knobs that don't affect a trained model's forward pass. Every error message links users to open an issue if they need an unsupported case.

### Verification

Validated end-to-end by loading each model in both frameworks and comparing the deterministic forward pass (latent, `px.mean`, `px.log_prob`, reconstruction) across 7 models — three real trained checkpoints (immune, HLCA, and a 261 MB / 40k-gene Parse-Bio model with `mean_activation`) plus trained models covering `decoder_reuse_weights="nowhere"`, `gene-batch`, and `gene-cell`:

- **Bit-exact** (`Δ = 0.0`) for all `gene` and `gene-batch` models.
- **`gene-cell`** matches to `~1e-6` — an inherent last-ULP difference (drvi adds its `+1` outside a nonlinear `logsumexp`, which checkpoint surgery can only fold inside); numerically identical distributions.

Unit tests in `tests/utils/test_porting.py` (6 tests) cover the key remaps, transposes, all three dispersion modes, no-overwrite behavior, and capability errors.
